### PR TITLE
[DEVX-655] Fix dry gems dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     trixie (0.1.2)
       dry-cli (~> 0.7.0)
+      dry-schema (~> 1.10.0)
       dry-validation (~> 1.8.0)
 
 GEM
@@ -28,14 +29,13 @@ GEM
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.9, >= 0.9)
       zeitwerk (~> 2.6)
-    dry-schema (1.11.3)
+    dry-schema (1.10.6)
       concurrent-ruby (~> 1.0)
-      dry-configurable (~> 0.16, >= 0.16)
-      dry-core (~> 0.9, >= 0.9)
+      dry-configurable (~> 0.13, >= 0.13.0)
+      dry-core (~> 0.5, >= 0.5)
       dry-initializer (~> 3.0)
-      dry-logic (~> 1.3)
-      dry-types (~> 1.6)
-      zeitwerk (~> 2.6)
+      dry-logic (~> 1.2)
+      dry-types (~> 1.5)
     dry-types (1.6.1)
       concurrent-ruby (~> 1.0)
       dry-container (~> 0.3)

--- a/trixie.gemspec
+++ b/trixie.gemspec
@@ -32,5 +32,6 @@ Gem::Specification.new do |spec|
   # For more information and examples about making a new gem, checkout our
   # guide at: https://bundler.io/guides/creating_gem.html
   spec.add_dependency "dry-cli", "~> 0.7.0"
+  spec.add_dependency "dry-schema", "~> 1.10.0"
   spec.add_dependency "dry-validation", "~> 1.8.0"
 end


### PR DESCRIPTION
## Description

`master` is failing with:

```ruby
NameError:
  uninitialized constant Dry::Schema::PredicateRegistry
# ./lib/trixie.rb:8:in `require'
# ./lib/trixie.rb:8:in `<top (required)>'
# ./spec/spec_helper.rb:3:in `require'
# ./spec/spec_helper.rb:3:in `<top (required)>'
```

It seems to be a compatibility issue with a dry-schema gem, this PR downgrades it to a previous version to keep compatibility. 