### PR TITLE
Bump rexml and rubocop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
     rainbow (3.1.1)
     rake (13.2.1)
     regexp_parser (2.5.0)
-    rexml (3.3.4)
+    rexml (3.3.6)
       strscan
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -78,7 +78,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.0)
-    rubocop (1.35.0)
+    rubocop (1.36.0)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.1.2.1)


### PR DESCRIPTION
Bumps rexml manually to fix https://github.com/toptal/trixie/security/dependabot/4. Dependabot failed to create PR on its own. I include dump of rubocop as it's using rexml as well.

### Testing

I guess CI...
