### PR TITLE
[DEVX-5035] Add DevX label to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,7 @@ updates:
       - "no-jira"
       - "ruby"
       - "dependencies"
+      - "DevX"
     reviewers:
       - "toptal/devx"
     registries:
@@ -37,6 +38,7 @@ updates:
       - "no-jira"
       - "dependencies"
       - "gha"
+      - "DevX"
     reviewers:
       - "toptal/devx"
     open-pull-requests-limit: 2


### PR DESCRIPTION
https://toptal-core.atlassian.net/browse/DEVX-5035

This PR adds DevX label to PRs created by dependabot. This simplifies handling of them (it's easier to keep them visible in Seal).